### PR TITLE
Fix: Parralel middlewares should not dail to report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 emt.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-middleware-timer",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "description": "A simple timer implementation for debugging express middleware.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I started using `middleware-flow` and suddenly timers got all wrong.

I poked at the code and realized it was assuming a flat sequence of middlewares. So I fixed it.

This PR:
  * Makes sure we calculate times accurately regardless of previous chain of middlewares.
  * Changes internals a bit, but keep all APIs and outputs the same
  * Updates to 1.0.0 since I believe internals is not enough to keep this update from breaking old codebases
  * Update tests and add a new one for parallel flow.
  * Add package-lock.json to git ignore, so we keep old behavior for this very old middeware 😄 